### PR TITLE
Add details on child jobs to report

### DIFF
--- a/lib/factory_bot_profiler/factory_stat.rb
+++ b/lib/factory_bot_profiler/factory_stat.rb
@@ -1,18 +1,25 @@
 module FactoryBotProfiler
   class FactoryStat
-    attr_reader :name, :count, :total_time, :total_child_time
+    attr_reader :name, :count, :total_time, :total_child_time, :individual_child_times, :individual_child_count
 
     def initialize(name)
       @name = name
       @count = 0
       @total_time = 0
       @total_child_time = 0
+      @individual_child_times = Hash.new { 0 }
+      @individual_child_count = Hash.new { 0 }
     end
 
     def increment(frame)
       @count += 1
       @total_time += frame.duration
-      @total_child_time += frame.child_time
+      @total_child_time += frame.total_child_time
+
+      frame.child_time.each do |factory_name, time|
+        @individual_child_times[factory_name] += time
+        @individual_child_count[factory_name] += 1
+      end
     end
 
     def average_time

--- a/lib/factory_bot_profiler/frame.rb
+++ b/lib/factory_bot_profiler/frame.rb
@@ -1,19 +1,38 @@
 module FactoryBotProfiler
   class Frame
-    attr_accessor :name, :start, :duration, :child_time
+    attr_accessor :name, :start, :child_time, :child_count
 
     def initialize(name)
       @name = name
       @start = Time.now
-      @child_time = 0
+      @child_time = Hash.new { 0 }
+      @child_count = Hash.new { 0 }
     end
 
     def observe_child(frame)
-      @child_time += frame.duration
+      @child_count[frame.name] += 1
+
+      @child_time[frame.name] += frame.self_time
+      frame.child_time.each do |factory_name, time|
+        @child_time[factory_name] += time
+      end
+    end
+
+    def duration
+      raise "self time called before frame was stopped" unless @duration
+      @duration
     end
 
     def finish!
       @duration = Time.now - @start
+    end
+
+    def self_time
+      duration - total_child_time
+    end
+
+    def total_child_time
+      @child_time.values.sum
     end
   end
 end

--- a/lib/factory_bot_profiler/reporters/simple_reporter.rb
+++ b/lib/factory_bot_profiler/reporters/simple_reporter.rb
@@ -17,16 +17,22 @@ module FactoryBotProfiler
         @collector.highest_total_time(N).each do |stat|
           puts "    - :#{stat.name} factory took #{(stat.total_time).round(2)} seconds overall"
           puts "       (#{stat.total_child_time.round(2)} seconds spent in associated child factories)" unless stat.total_child_time.zero?
+          puts
         end
         puts
         puts "  Slowest factories on average:"
         @collector.highest_average_time(N).each do |stat|
-          puts "    - :#{stat.name} factory took #{(stat.average_time).round(2)} seconds on average"
+          puts "    - :#{stat.name} factory took #{(stat.average_time).round(2)} seconds on average (called #{stat.count} times)"
+          stat.individual_child_times.each do |factory_name, time|
+            puts "      - #{time.round(2)} spent in :#{factory_name} called #{stat.individual_child_count[factory_name]}/#{stat.count} time(s)"
+          end
+          puts
         end
         puts
         puts "  Most used factories:"
         @collector.highest_count(N).each do |stat|
           puts "    - :#{stat.name} factory ran #{stat.count} times"
+          puts
         end
       end
     end


### PR DESCRIPTION
Updated report looks like:

```
++++++++ factory_bot stats:

  Spent 2.31 seconds in factory_bot

  Factories taking most time overall:
    - :organization factory took 1.61 seconds overall
       (0.81 seconds spent in associated child factories)

    - :repository factory took 1.41 seconds overall
       (1.21 seconds spent in associated child factories)

    - :user factory took 1.21 seconds overall
       (0.3 seconds spent in associated child factories)

    - :profile factory took 0.41 seconds overall

  Slowest factories on average:
    - :repository factory took 1.41 seconds on average
      - 0.6 spent in :user called 1/1 time(s)
      - 0.2 spent in :profile called 1/1 time(s)
      - 0.4 spent in :organization called 1/1 time(s)

    - :organization factory took 0.8 seconds on average
      - 0.6 spent in :user called 2/2 time(s)
      - 0.2 spent in :profile called 2/2 time(s)

    - :user factory took 0.4 seconds on average
      - 0.3 spent in :profile called 3/3 time(s)

    - :profile factory took 0.1 seconds on average

  Most used factories:
    - :profile factory ran 4 times

    - :user factory ran 3 times

    - :organization factory ran 2 times

    - :repository factory ran 1 times
```