### PR TITLE
Allow merging collectors

### DIFF
--- a/.standard.yml
+++ b/.standard.yml
@@ -1,3 +1,3 @@
 # For available configuration options, see:
 #   https://github.com/testdouble/standard
-ruby_version: 2.6
+ruby_version: 3.0

--- a/lib/factory_bot_profiler.rb
+++ b/lib/factory_bot_profiler.rb
@@ -17,4 +17,9 @@ module FactoryBotProfiler
   def self.report(reporter_class = Reporters::SimpleReporter)
     reporter_class.new(@collector).report if @collector
   end
+
+  def self.merge_and_report(collectors, reporter_class = Reporters::SimpleReporter)
+    merged = collectors.reduce(Collector.new, &:merge!)
+    reporter_class.new(merged).report
+  end
 end

--- a/lib/factory_bot_profiler/collector.rb
+++ b/lib/factory_bot_profiler/collector.rb
@@ -30,6 +30,18 @@ module FactoryBotProfiler
       take_factory_values_by(:average_time, n)
     end
 
+    def merge!(other)
+      other.each_factory do |name, stat|
+        @by_factory[name].merge!(stat)
+      end
+
+      self
+    end
+
+    def each_factory(...)
+      @by_factory.each(...)
+    end
+
     private
 
     def take_factory_values_by(stat, n)

--- a/lib/factory_bot_profiler/factory_stat.rb
+++ b/lib/factory_bot_profiler/factory_stat.rb
@@ -22,5 +22,13 @@ module FactoryBotProfiler
     def total_self_time
       total_time - total_child_time
     end
+
+    def merge!(other)
+      raise "attempting to merge unrelated stats" if name != other.name
+
+      @count += other.count
+      @total_time += other.total_time
+      @total_child_time += other.total_child_time
+    end
   end
 end


### PR DESCRIPTION
This can be helpful if you are running tests in multiple processes and
you want to merge together the results after everything finished.