### PR TITLE
Rename Collector to AggregateStats

### DIFF
--- a/lib/factory_bot_profiler.rb
+++ b/lib/factory_bot_profiler.rb
@@ -3,23 +3,23 @@
 require "active_support/notifications"
 
 require_relative "factory_bot_profiler/version"
-require_relative "factory_bot_profiler/collector"
+require_relative "factory_bot_profiler/aggregate_stats"
 require_relative "factory_bot_profiler/subscriber"
 require_relative "factory_bot_profiler/reporters/simple_reporter"
 
 module FactoryBotProfiler
-  def self.subscribe(collector = Collector.new)
-    @collector = collector
-    subscriber = FactoryBotProfiler::Subscriber.new(@collector)
+  def self.subscribe(stats = AggregateStats.new)
+    @stats = stats
+    subscriber = FactoryBotProfiler::Subscriber.new(stats)
     ActiveSupport::Notifications.subscribe("factory_bot.run_factory", subscriber)
   end
 
   def self.report(reporter_class = Reporters::SimpleReporter)
-    reporter_class.new(@collector).report if @collector
+    reporter_class.new(@stats).report if @stats
   end
 
-  def self.merge_and_report(collectors, reporter_class = Reporters::SimpleReporter)
-    merged = collectors.reduce(Collector.new, &:merge!)
-    reporter_class.new(merged).report
+  def self.merge_and_report(all_stats, reporter_class = Reporters::SimpleReporter)
+    merged_stats = all_stats.reduce(AggregateStats.new, &:merge!)
+    reporter_class.new(merged_stats).report
   end
 end

--- a/lib/factory_bot_profiler/aggregate_stats.rb
+++ b/lib/factory_bot_profiler/aggregate_stats.rb
@@ -1,7 +1,7 @@
 require_relative "factory_stat"
 
 module FactoryBotProfiler
-  class Collector
+  class AggregateStats
     def initialize
       @by_factory = stats_hash
     end

--- a/lib/factory_bot_profiler/reporters/simple_reporter.rb
+++ b/lib/factory_bot_profiler/reporters/simple_reporter.rb
@@ -3,25 +3,25 @@ module FactoryBotProfiler
     class SimpleReporter
       N = 4
 
-      def initialize(collector)
-        @collector = collector
+      def initialize(stats)
+        @stats = stats
       end
 
       def report
         puts
         puts "++++++++ factory_bot stats:"
         puts
-        puts "  Spent #{(@collector.total_time).round(2)} seconds in factory_bot"
+        puts "  Spent #{(@stats.total_time).round(2)} seconds in factory_bot"
         puts
         puts "  Factories taking most time overall:"
-        @collector.highest_total_time(N).each do |stat|
+        @stats.highest_total_time(N).each do |stat|
           puts "    - :#{stat.name} factory took #{(stat.total_time).round(2)} seconds overall"
           puts "       (#{stat.total_child_time.round(2)} seconds spent in associated child factories)" unless stat.total_child_time.zero?
           puts
         end
         puts
         puts "  Slowest factories on average:"
-        @collector.highest_average_time(N).each do |stat|
+        @stats.highest_average_time(N).each do |stat|
           puts "    - :#{stat.name} factory took #{(stat.average_time).round(2)} seconds on average (called #{stat.count} times)"
           stat.individual_child_times.each do |factory_name, time|
             puts "      - #{time.round(2)} spent in :#{factory_name} called #{stat.individual_child_count[factory_name]}/#{stat.count} time(s)"
@@ -30,7 +30,7 @@ module FactoryBotProfiler
         end
         puts
         puts "  Most used factories:"
-        @collector.highest_count(N).each do |stat|
+        @stats.highest_count(N).each do |stat|
           puts "    - :#{stat.name} factory ran #{stat.count} times"
           puts
         end

--- a/lib/factory_bot_profiler/subscriber.rb
+++ b/lib/factory_bot_profiler/subscriber.rb
@@ -2,9 +2,9 @@ require_relative "stack"
 
 module FactoryBotProfiler
   class Subscriber
-    def initialize(collector)
+    def initialize(stats)
       @stack = Stack.new
-      @collector = collector
+      @stats = stats
     end
 
     def start(_, _, payload)
@@ -12,7 +12,7 @@ module FactoryBotProfiler
     end
 
     def finish(*)
-      @collector.collect(@stack.pop)
+      @stats.collect(@stack.pop)
     end
   end
 end

--- a/spec/factory_bot_profiler_spec.rb
+++ b/spec/factory_bot_profiler_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe FactoryBotProfiler do
       factory :profile
     end
 
-    collector = FactoryBotProfiler::Collector.new
-    FactoryBotProfiler.subscribe(collector)
+    stats = FactoryBotProfiler::AggregateStats.new
+    FactoryBotProfiler.subscribe(stats)
 
     FactoryBot.create(:repository) #   1 repo, 1 org, 2 users, 2 profiles
     FactoryBot.create(:organization) #         1 org, 1 user,  1 profile
@@ -66,21 +66,21 @@ RSpec.describe FactoryBotProfiler do
 
     FactoryBotProfiler.report if ENV["DEBUG"]
 
-    expect(collector.total_time.round(1)).to eq(2.3)
+    expect(stats.total_time.round(1)).to eq(2.3)
 
-    highest_count = collector.highest_count(1).first
+    highest_count = stats.highest_count(1).first
     expect(highest_count.name).to eq(:profile)
     expect(highest_count.count).to eq(4)
 
-    highest_total_time = collector.highest_total_time(1).first
+    highest_total_time = stats.highest_total_time(1).first
     expect(highest_total_time.name).to eq(:organization)
     expect(highest_total_time.total_time.round(1)).to eq(1.6)
 
-    highest_self_time = collector.highest_self_time(1).first
+    highest_self_time = stats.highest_self_time(1).first
     expect(highest_self_time.name).to eq(:user)
     expect(highest_self_time.total_self_time.round(1)).to eq(0.9)
 
-    highest_average_time = collector.highest_average_time(1).first
+    highest_average_time = stats.highest_average_time(1).first
     expect(highest_average_time.name).to eq(:repository)
     expect(highest_average_time.average_time.round(1)).to eq(1.4)
   end
@@ -135,8 +135,8 @@ RSpec.describe FactoryBotProfiler do
       factory :seat_warmer
     end
 
-    collector = FactoryBotProfiler::Collector.new
-    FactoryBotProfiler.subscribe(collector)
+    stats = FactoryBotProfiler::AggregateStats.new
+    FactoryBotProfiler.subscribe(stats)
 
     FactoryBot.create(:car)
     FactoryBot.create(:car, :ex)
@@ -144,9 +144,9 @@ RSpec.describe FactoryBotProfiler do
 
     FactoryBotProfiler.report if ENV["DEBUG"]
 
-    expect(collector.total_time.round(1)).to eq(2.1)
+    expect(stats.total_time.round(1)).to eq(2.1)
 
-    highest_total_time = collector.highest_total_time(1).first
+    highest_total_time = stats.highest_total_time(1).first
     expect(highest_total_time.name).to eq(:car)
 
     expect(highest_total_time.individual_child_times[:moon_roof].round(1)).to eq(0.6)


### PR DESCRIPTION
The name Collector seems off to me. There's one method for collecting
stats, but the bulk of the class is sorting and filtering the various
FactoryStats for use in the Reporter. John suggested AggregateStats,
which I like a lot more and seems to fit with what the class is doing.