### PR TITLE
Make SimpleReport line count configurable

### DIFF
--- a/lib/factory_bot_profile.rb
+++ b/lib/factory_bot_profile.rb
@@ -22,12 +22,12 @@ module FactoryBotProfile
     Subscription.new(stats).subscribe
   end
 
-  def self.report(stats, reporter: Report::SimpleReport, io: $stdout)
-    reporter.new(stats, io: io).deliver if stats
+  def self.report(stats, reporter: Report::SimpleReport, **options)
+    reporter.new(stats, **options).deliver if stats
   end
 
-  def self.merge_and_report(all_stats, reporter: Report::SimpleReport, io: $stdout)
+  def self.merge_and_report(all_stats, reporter: Report::SimpleReport, **options)
     merged_stats = all_stats.reduce(AggregateStats.new, &:merge!)
-    report(merged_stats, reporter: reporter, io: io)
+    report(merged_stats, reporter: reporter, **options)
   end
 end

--- a/lib/factory_bot_profile/report/simple_report.rb
+++ b/lib/factory_bot_profile/report/simple_report.rb
@@ -1,9 +1,10 @@
 module FactoryBotProfile
   module Report
     class SimpleReport
-      def initialize(stats, io: $stdout)
+      def initialize(stats, io: $stdout, count: 3)
         @stats = stats
         @io = io
+        @count = count
       end
 
       def deliver
@@ -13,7 +14,7 @@ module FactoryBotProfile
         io.puts "  Spent #{stats.total_time.round(2)} seconds in factory_bot"
         io.puts
         io.puts "  Factories taking the most time overall:"
-        stats.highest_total_time(3).each do |stat|
+        stats.highest_total_time(count).each do |stat|
           io.puts "    - :#{stat.name} factory took #{stat.total_time.round(2)} seconds overall (ran #{stat.count} times)"
           stat.child_stats_by_total_time.reverse_each do |child_stat|
             io.puts "      - #{child_stat.total_time.round(2)} seconds spent in :#{child_stat.name} (ran #{child_stat.count}/#{stat.count} times)"
@@ -22,7 +23,7 @@ module FactoryBotProfile
         end
         io.puts
         io.puts "  Slowest factories on average:"
-        stats.highest_average_time(3).each do |stat|
+        stats.highest_average_time(count).each do |stat|
           io.puts "    - :#{stat.name} factory took #{stat.average_time.round(2)} seconds on average (ran #{stat.count} times)"
           stat.child_stats_by_average_time.reverse_each do |child_stat|
             io.puts "      - #{child_stat.average_time.round(2)} seconds spent in :#{child_stat.name} on average (ran #{child_stat.count}/#{stat.count} times)"
@@ -31,14 +32,14 @@ module FactoryBotProfile
         end
         io.puts
         io.puts "  Most used factories:"
-        stats.highest_count(5).each do |stat|
+        stats.highest_count(count).each do |stat|
           io.puts "    - :#{stat.name} factory ran #{stat.count} times"
         end
       end
 
       private
 
-      attr_reader :stats, :io
+      attr_reader :stats, :io, :count
     end
   end
 end

--- a/spec/factory_bot_profile_spec.rb
+++ b/spec/factory_bot_profile_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe FactoryBotProfile do
 
   def generate_test_report(stats, name)
     File.open("tmp/test_reports/#{name}.txt", "w") do |f|
-      FactoryBotProfile.report(stats, io: f)
+      FactoryBotProfile.report(stats, io: f, count: 4)
     end
   end
 end


### PR DESCRIPTION
I've already changed the counts here a couple times, and now other folks are wanting different counts as well.

This commit makes the count configurable by passing an option to the report method.

Rather than treating io and count as special configurable properties, now we forward the whole options hash to the report class. This makes it possible to pass arbitrary options to any custom reporter classes as well.